### PR TITLE
fix(progress): video already downloaded message not working properly …

### DIFF
--- a/web/components/job-progress.tsx
+++ b/web/components/job-progress.tsx
@@ -55,7 +55,7 @@ const JobProgress: React.FC = () => {
                                     <span>Download Finished</span>
                                     ) :
                                     (
-                                        job.progress > 100 ? (
+                                        job.currentVideoProgress > 100 ? (
                                             <span>Video already downloaded</span>
                                             ) : (
                                             <span>Downloading {job.jobType} ({job.currentVideoProgress}%)</span>


### PR DESCRIPTION
…when downloading a playlist twice

- Add alreadyDownloaded flag and conditionally set the currentVideoProgress to the actual progress or 101