### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-lint.yml
+++ b/.github/workflows/build-lint.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
 jobs:
   docker_compose_build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Fx64b/video-archiver/security/code-scanning/9](https://github.com/Fx64b/video-archiver/security/code-scanning/9)

To fix this issue, you should add an explicit `permissions` block to the workflow YAML. The best practice is to add this at the root level (before `jobs:`) if you want these permissions to apply to all jobs that do not themselves declare a `permissions` block. In this case, since none of the jobs require write access (no publishing, issue, or PR manipulation), the minimal permission required is `contents: read`. This change only involves adding a block:

```yaml
permissions:
  contents: read
```

between the `on:` and `jobs:` blocks. No changes to imports, logic, or steps are required—just the addition of this YAML block to `.github/workflows/build-lint.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
