### PR TITLE
Store and display download errors as warnings

### DIFF
--- a/services/backend/db/schema.sql
+++ b/services/backend/db/schema.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS jobs (
                                     is_playlist BOOLEAN DEFAULT FALSE,
                                     status TEXT,
                                     progress REAL,
+                                    warnings TEXT,
                                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/services/backend/internal/domain/job.go
+++ b/services/backend/internal/domain/job.go
@@ -17,6 +17,7 @@ type Job struct {
 	Status        JobStatus `json:"status"`
 	Progress      float64   `json:"progress"`
 	CustomQuality *int      `json:"custom_quality,omitempty"`
+	Warnings      []string  `json:"warnings,omitempty"`
 	CreatedAt     time.Time `json:"created_at"`
 	UpdatedAt     time.Time `json:"updated_at"`
 }
@@ -68,6 +69,7 @@ type ProgressUpdate struct {
 	RetryCount           int       `json:"retryCount,omitempty"`
 	MaxRetries           int       `json:"maxRetries,omitempty"`
 	RetryError           string    `json:"retryError,omitempty"`
+	Warnings             []string  `json:"warnings,omitempty"`
 }
 
 const (

--- a/services/backend/internal/testutil/helpers.go
+++ b/services/backend/internal/testutil/helpers.go
@@ -25,6 +25,7 @@ func CreateTestDB(t *testing.T) *sql.DB {
 		url TEXT NOT NULL,
 		status TEXT NOT NULL,
 		progress REAL NOT NULL,
+		warnings TEXT,
 		created_at DATETIME NOT NULL,
 		updated_at DATETIME NOT NULL
 	);
@@ -78,6 +79,7 @@ func CreateTestJob(id, url string) *domain.Job {
 		URL:       url,
 		Status:    domain.JobStatusPending,
 		Progress:  0,
+		Warnings:  []string{},
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	}

--- a/web/components/metadata-card.tsx
+++ b/web/components/metadata-card.tsx
@@ -10,9 +10,9 @@ import {
     Metadata,
     ProgressUpdate,
 } from '@/types'
-import { AlertTriangle, CircleCheck, Clock, User } from 'lucide-react'
+import { AlertTriangle, CircleCheck, Clock, User, ChevronDown, ChevronUp } from 'lucide-react'
 
-import React from 'react'
+import React, { useState } from 'react'
 
 import Image from 'next/image'
 
@@ -37,6 +37,7 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
     metadata,
     job,
 }) => {
+    const [showWarnings, setShowWarnings] = useState(false)
     const thumbnailUrl = getThumbnailUrl(metadata)
     const title = getTitle(metadata)
 
@@ -51,6 +52,7 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
 
     const isRetrying = 'isRetrying' in job && job.isRetrying
     const isFailed = 'status' in job && job.status === JobStatusError
+    const hasWarnings = 'warnings' in job && job.warnings && job.warnings.length > 0
 
     return (
         <Card className="relative w-full">
@@ -185,6 +187,41 @@ export const MetadataCard: React.FC<MetadataCardProps> = ({
                             </div>
                         </div>
                         <Progress value={getJobProgress()} className="mt-2" />
+
+                        {/* Warnings Section */}
+                        {hasWarnings && (
+                            <div className="mt-4">
+                                <button
+                                    onClick={() => setShowWarnings(!showWarnings)}
+                                    className="flex w-full items-center justify-between rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-600 transition-colors hover:bg-yellow-500/20 dark:text-yellow-500"
+                                >
+                                    <div className="flex items-center gap-2">
+                                        <AlertTriangle className="h-4 w-4" />
+                                        <span className="font-medium">
+                                            {job.warnings!.length} warning{job.warnings!.length !== 1 ? 's' : ''} detected
+                                        </span>
+                                    </div>
+                                    {showWarnings ? (
+                                        <ChevronUp className="h-4 w-4" />
+                                    ) : (
+                                        <ChevronDown className="h-4 w-4" />
+                                    )}
+                                </button>
+                                {showWarnings && (
+                                    <div className="mt-2 space-y-2 rounded-md border border-yellow-500/30 bg-yellow-500/5 p-3">
+                                        {job.warnings!.map((warning, index) => (
+                                            <div
+                                                key={index}
+                                                className="flex items-start gap-2 text-sm text-muted-foreground"
+                                            >
+                                                <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-yellow-600 dark:text-yellow-500" />
+                                                <span className="break-words">{warning}</span>
+                                            </div>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        )}
                     </CardContent>
                 </div>
             </div>

--- a/web/types/index.ts
+++ b/web/types/index.ts
@@ -14,6 +14,7 @@ export interface Job {
   status: JobStatus;
   progress: number /* float64 */;
   custom_quality?: number /* int */;
+  warnings?: string[];
   created_at: string /* RFC3339 */;
   updated_at: string /* RFC3339 */;
 }
@@ -43,6 +44,7 @@ export interface ProgressUpdate {
   retryCount?: number /* int */;
   maxRetries?: number /* int */;
   retryError?: string;
+  warnings?: string[];
 }
 export const DownloadPhaseMetadata = "metadata";
 export const DownloadPhaseVideo = "video";


### PR DESCRIPTION
- Add warnings field to Job and ProgressUpdate entities
- Update database schema with warnings column and migration
- Update repository to serialize/deserialize warnings as JSON
- Collect download errors in progress tracker and store in database
- Add expandable warnings section in MetadataCard component
- Update TypeScript types to include warnings field

This allows users to see detailed error messages for failed videos in playlists/channels (e.g., private videos, removed videos) without failing the entire download job.