### PR TITLE
Add ability to cancel downloads

### DIFF
--- a/services/backend/internal/domain/job.go
+++ b/services/backend/internal/domain/job.go
@@ -9,6 +9,7 @@ const (
 	JobStatusInProgress JobStatus = "in_progress"
 	JobStatusComplete   JobStatus = "complete"
 	JobStatusError      JobStatus = "error"
+	JobStatusCancelled  JobStatus = "cancelled"
 )
 
 type Job struct {

--- a/web/types/index.ts
+++ b/web/types/index.ts
@@ -8,6 +8,7 @@ export const JobStatusPending: JobStatus = "pending";
 export const JobStatusInProgress: JobStatus = "in_progress";
 export const JobStatusComplete: JobStatus = "complete";
 export const JobStatusError: JobStatus = "error";
+export const JobStatusCancelled: JobStatus = "cancelled";
 export interface Job {
   id: string;
   url: string;


### PR DESCRIPTION
Backend changes:
- Add JobStatusCancelled constant to domain/job.go
- Update download service to track active jobs with cancellable contexts
- Add CancelJob method to terminate running downloads
- Add DELETE /download/{id} API endpoint

Frontend changes:
- Add JobStatusCancelled to TypeScript types
- Add cancel button to MetadataCard component for in-progress downloads
- Display "Download Cancelled" status for cancelled jobs
- Add toast notifications for cancel success/failure

The cancel button appears in the top-right corner of download cards that are pending or in progress, allowing users to stop downloads mid-execution. The backend uses per-job contexts to gracefully terminate yt-dlp processes.