### PR TITLE
Add tagging system and download deletion for library management

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Video Archiver allows you to download and organize videos from YouTube for offli
 - Dark/Light/System theme support
 - Dashboard with comprehensive statistics about your media collection
 - Complete metadata extraction and display (videos, playlists, channels)
+- **Tagging and auto-tagging**: organize your library with custom tags; categories, channel names and keywords are tagged automatically from metadata
+- **Search and filtering**: full library search by title or channel, plus tag-based filtering
+- Library management: delete downloads (including files on disk) with confirmation
 - Quality selection (360p, 480p, 720p, 1080p, 1440p, 4K)
 - Configurable concurrent downloads (1-10 simultaneous downloads)
 - **Video Processing Tools:**
@@ -33,10 +36,9 @@ Video Archiver allows you to download and organize videos from YouTube for offli
   - Rotate videos (90°, 180°, 270°)
   - Create custom workflows (chain multiple operations)
 - Real-time progress tracking for tool operations
+- Processed file management: preview (in-browser playback), download and delete tool outputs
 
 ### Planned Features
-- Enhanced metadata management and organization
-- Advanced search and categorization
 - Mobile-friendly streaming interface
 - User authentication and multiple user support
 - Download scheduling
@@ -209,5 +211,5 @@ This project is licensed under the GNU General Public License v3.0 - see the [LI
 See the [open issues](https://github.com/Fx64b/video-archiver/issues) for a list of proposed features and known issues.
 
 - ✅ ~~Q3 2025: Media streaming interface & Tools~~ (Tools completed)
-- Q4 2025: Advanced search and tagging system
+- ✅ ~~Q4 2025: Advanced search and tagging system~~ (Search, tagging and auto-tagging completed)
 - 2026: User authentication, API documentation, and mobile-friendly streaming

--- a/services/backend/cmd/api/main.go
+++ b/services/backend/cmd/api/main.go
@@ -56,6 +56,14 @@ __     _____ ____  _____ ___
 	settingsRepo := sqlite.NewSettingsRepository(db)
 	toolsRepo := sqlite.NewToolsRepository(db)
 
+	// Tag items downloaded before auto-tagging existed; idempotent, so it can
+	// run on every startup without growing the tag set.
+	go func() {
+		if err := jobRepo.BackfillAutoTags(); err != nil {
+			log.WithError(err).Warn("Auto-tag backfill failed")
+		}
+	}()
+
 	fmt.Println("Starting Download Service...")
 	downloadService := download.NewService(&download.Config{
 		JobRepository:      jobRepo,

--- a/services/backend/db/schema.sql
+++ b/services/backend/db/schema.sql
@@ -75,6 +75,24 @@ CREATE TABLE IF NOT EXISTS tools_jobs (
                                           actual_size INTEGER
 );
 
+CREATE TABLE IF NOT EXISTS tags (
+                                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                                    name TEXT NOT NULL UNIQUE COLLATE NOCASE,
+                                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS job_tags (
+                                        job_id TEXT NOT NULL,
+                                        tag_id INTEGER NOT NULL,
+                                        source TEXT NOT NULL DEFAULT 'user',
+                                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                        PRIMARY KEY (job_id, tag_id),
+                                        FOREIGN KEY (job_id) REFERENCES jobs (job_id),
+                                        FOREIGN KEY (tag_id) REFERENCES tags (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_tags_tag_id ON job_tags(tag_id);
+
 CREATE INDEX IF NOT EXISTS idx_tools_jobs_status ON tools_jobs(status);
 CREATE INDEX IF NOT EXISTS idx_tools_jobs_created_at ON tools_jobs(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_tools_jobs_operation_type ON tools_jobs(operation_type);

--- a/services/backend/generated/types/index.ts
+++ b/services/backend/generated/types/index.ts
@@ -21,6 +21,17 @@ export interface Job {
 }
 
 export type JobRepository = any;
+/**
+ * MetadataQuery holds the listing options for GetMetadataByType.
+ */
+export interface MetadataQuery {
+  Page: number /* int */;
+  Limit: number /* int */;
+  SortBy: string;
+  Order: string;
+  Search: string; // case-insensitive match against title/channel
+  Tag: string; // only items carrying this tag
+}
 export type JobType = string;
 export const JobTypeVideo: JobType = "video";
 export const JobTypeAudio: JobType = "audio";
@@ -31,6 +42,7 @@ export const JobTypeMetadata: JobType = "metadata";
 export interface JobWithMetadata {
   job?: Job;
   metadata?: Metadata;
+  tags?: Tag[];
 }
 export interface ProgressUpdate {
   jobID: string;
@@ -191,6 +203,29 @@ export interface VideoStorageInfo {
   title: string;
   size: number /* int */;
   channel: string;
+}
+
+//////////
+// source: tags.go
+
+/**
+ * TagSource records how a tag got attached to a job.
+ */
+export const TagSourceUser = "user";
+/**
+ * TagSource records how a tag got attached to a job.
+ */
+export const TagSourceAuto = "auto";
+/**
+ * Tag is a label attached to a downloaded video, playlist or channel. Count is
+ * only populated when listing the tag catalog; Source is only populated when a
+ * tag is returned in the context of a specific job.
+ */
+export interface Tag {
+  id: number /* int64 */;
+  name: string;
+  source?: string;
+  count?: number /* int */;
 }
 
 //////////

--- a/services/backend/internal/api/handlers/handlers.go
+++ b/services/backend/internal/api/handlers/handlers.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi"
@@ -68,8 +70,13 @@ func (h *Handler) RegisterRoutes(r *chi.Mux) {
 	r.Delete("/download/{id}", h.HandleCancelDownload)
 	r.Get("/recent", h.HandleRecent)
 	r.Get("/job/{id}", h.HandleGetJob)
+	r.Delete("/job/{id}", h.HandleDeleteJob)
 	r.Get("/job/{id}/parents", h.HandleGetJobParents)
 	r.Get("/job/{id}/videos", h.HandleGetJobVideos)
+	r.Get("/job/{id}/tags", h.HandleGetJobTags)
+	r.Post("/job/{id}/tags", h.HandleAddJobTags)
+	r.Delete("/job/{id}/tags/{tagID}", h.HandleRemoveJobTag)
+	r.Get("/tags", h.HandleListTags)
 	r.Get("/statistics", h.HandleGetStatistics)
 	r.Get("/downloads/{type}", h.HandleGetDownloads)
 	r.Get("/video/{jobID}", h.HandleServeVideo)
@@ -239,6 +246,114 @@ func (h *Handler) HandleGetJob(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, Response{Message: jobWithMetadata})
 }
 
+// HandleDeleteJob removes a download from the library, including the media
+// file on disk for videos. Running jobs are cancelled before deletion.
+func (h *Handler) HandleDeleteJob(w http.ResponseWriter, r *http.Request) {
+	jobID := chi.URLParam(r, "id")
+	if jobID == "" {
+		http.Error(w, "Missing job ID", http.StatusBadRequest)
+		return
+	}
+
+	log.Infof("Received delete request for job: %s", jobID)
+
+	if err := h.downloadService.DeleteJob(jobID); err != nil {
+		log.WithError(err).Error("Failed to delete job")
+		if strings.Contains(err.Error(), "not found") {
+			http.Error(w, "Job not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "Failed to delete job", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, Response{Message: "Download deleted successfully"})
+}
+
+func (h *Handler) HandleListTags(w http.ResponseWriter, r *http.Request) {
+	tags, err := h.downloadService.GetRepository().ListTags()
+	if err != nil {
+		log.WithError(err).Error("Failed to list tags")
+		http.Error(w, "Failed to list tags", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, Response{Message: tags})
+}
+
+func (h *Handler) HandleGetJobTags(w http.ResponseWriter, r *http.Request) {
+	jobID := chi.URLParam(r, "id")
+	if jobID == "" {
+		http.Error(w, "Missing job ID", http.StatusBadRequest)
+		return
+	}
+
+	tags, err := h.downloadService.GetRepository().GetTagsForJob(jobID)
+	if err != nil {
+		log.WithError(err).Error("Failed to get tags for job")
+		http.Error(w, "Failed to get tags", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, Response{Message: tags})
+}
+
+type AddTagsRequest struct {
+	Tags []string `json:"tags"`
+}
+
+func (h *Handler) HandleAddJobTags(w http.ResponseWriter, r *http.Request) {
+	jobID := chi.URLParam(r, "id")
+	if jobID == "" {
+		http.Error(w, "Missing job ID", http.StatusBadRequest)
+		return
+	}
+
+	var req AddTagsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request payload", http.StatusBadRequest)
+		return
+	}
+	if len(req.Tags) == 0 {
+		http.Error(w, "At least one tag is required", http.StatusBadRequest)
+		return
+	}
+
+	// Make sure the job exists before tagging it.
+	if _, err := h.downloadService.GetRepository().GetByID(jobID); err != nil {
+		http.Error(w, "Job not found", http.StatusNotFound)
+		return
+	}
+
+	tags, err := h.downloadService.GetRepository().AddTagsToJob(jobID, req.Tags, domain.TagSourceUser)
+	if err != nil {
+		log.WithError(err).Error("Failed to add tags to job")
+		http.Error(w, "Failed to add tags", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, Response{Message: tags})
+}
+
+func (h *Handler) HandleRemoveJobTag(w http.ResponseWriter, r *http.Request) {
+	jobID := chi.URLParam(r, "id")
+	tagIDParam := chi.URLParam(r, "tagID")
+	if jobID == "" || tagIDParam == "" {
+		http.Error(w, "Missing job ID or tag ID", http.StatusBadRequest)
+		return
+	}
+
+	tagID, err := strconv.ParseInt(tagIDParam, 10, 64)
+	if err != nil {
+		http.Error(w, "Invalid tag ID", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.downloadService.GetRepository().RemoveTagFromJob(jobID, tagID); err != nil {
+		log.WithError(err).Error("Failed to remove tag from job")
+		http.Error(w, "Failed to remove tag", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, Response{Message: "Tag removed successfully"})
+}
+
 func (h *Handler) HandleGetJobParents(w http.ResponseWriter, r *http.Request) {
 	jobID := chi.URLParam(r, "id")
 	if jobID == "" {
@@ -315,7 +430,14 @@ func (h *Handler) HandleGetDownloads(w http.ResponseWriter, r *http.Request) {
 		order = "desc"
 	}
 
-	items, totalCount, err := h.downloadService.GetRepository().GetMetadataByType(contentType, page, limit, sortBy, order)
+	items, totalCount, err := h.downloadService.GetRepository().GetMetadataByType(contentType, domain.MetadataQuery{
+		Page:   page,
+		Limit:  limit,
+		SortBy: sortBy,
+		Order:  order,
+		Search: r.URL.Query().Get("search"),
+		Tag:    r.URL.Query().Get("tag"),
+	})
 	if err != nil {
 		log.WithError(err).Errorf("Failed to get %s", contentType)
 		http.Error(w, fmt.Sprintf("Failed to get %s", contentType), http.StatusInternalServerError)

--- a/services/backend/internal/api/handlers/tools.go
+++ b/services/backend/internal/api/handlers/tools.go
@@ -207,10 +207,18 @@ func (h *ToolsHandler) HandleServeOutput(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filepath.Base(path)))
+	// inline=1 lets the frontend preview the file (video/audio playback in
+	// the browser) instead of forcing a download.
+	disposition := "attachment"
+	if r.URL.Query().Get("inline") == "1" {
+		disposition = "inline"
+	}
+	w.Header().Set("Content-Disposition", fmt.Sprintf("%s; filename=%q", disposition, filepath.Base(path)))
 	http.ServeFile(w, r, path)
 }
 
+// HandleCancelJob cancels a queued/running job, or deletes a finished one
+// (record and output file) so processed files don't accumulate forever.
 func (h *ToolsHandler) HandleCancelJob(w http.ResponseWriter, r *http.Request) {
 	jobID := chi.URLParam(r, "id")
 	if jobID == "" {
@@ -218,12 +226,33 @@ func (h *ToolsHandler) HandleCancelJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.toolsService.CancelJob(jobID); err != nil {
-		log.WithError(err).Error("Failed to cancel tools job")
+	job, err := h.toolsService.GetJobByID(jobID)
+	if err != nil {
+		log.WithError(err).Error("Failed to get tools job")
+		http.Error(w, "Failed to get job", http.StatusInternalServerError)
+		return
+	}
+	if job == nil {
+		http.Error(w, "Job not found", http.StatusNotFound)
+		return
+	}
+
+	if job.Status == domain.ToolsJobStatusPending || job.Status == domain.ToolsJobStatusProcessing {
+		if err := h.toolsService.CancelJob(jobID); err != nil {
+			log.WithError(err).Error("Failed to cancel tools job")
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, Response{Message: "Job cancelled successfully"})
+		return
+	}
+
+	if err := h.toolsService.DeleteJob(jobID); err != nil {
+		log.WithError(err).Error("Failed to delete tools job")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	writeJSON(w, http.StatusOK, Response{Message: "Job cancelled successfully"})
+	writeJSON(w, http.StatusOK, Response{Message: "Job deleted successfully"})
 }
 
 func writeJSON(w http.ResponseWriter, status int, body any) {

--- a/services/backend/internal/domain/job.go
+++ b/services/backend/internal/domain/job.go
@@ -37,10 +37,26 @@ type JobRepository interface {
 	CountVideos() (int, error)
 	CountPlaylists() (int, error)
 	CountChannels() (int, error)
-	GetMetadataByType(contentType string, page int, limit int, sortBy string, order string) ([]*JobWithMetadata, int, error)
+	GetMetadataByType(contentType string, opts MetadataQuery) ([]*JobWithMetadata, int, error)
 	AddVideoToParent(videoJobID, parentJobID, membershipType string) error
 	GetVideosForParent(parentJobID string) ([]*JobWithMetadata, error)
 	GetParentsForVideo(videoJobID string) ([]*JobWithMetadata, error)
+	DeleteJob(jobID string) error
+	ListTags() ([]Tag, error)
+	GetTagsForJob(jobID string) ([]Tag, error)
+	AddTagsToJob(jobID string, names []string, source string) ([]Tag, error)
+	RemoveTagFromJob(jobID string, tagID int64) error
+	BackfillAutoTags() error
+}
+
+// MetadataQuery holds the listing options for GetMetadataByType.
+type MetadataQuery struct {
+	Page   int
+	Limit  int
+	SortBy string
+	Order  string
+	Search string // case-insensitive match against title/channel
+	Tag    string // only items carrying this tag
 }
 
 type JobType string
@@ -55,6 +71,7 @@ const (
 type JobWithMetadata struct {
 	Job      *Job     `json:"job"`
 	Metadata Metadata `json:"metadata,omitempty"`
+	Tags     []Tag    `json:"tags,omitempty"`
 }
 
 type ProgressUpdate struct {

--- a/services/backend/internal/domain/tags.go
+++ b/services/backend/internal/domain/tags.go
@@ -1,0 +1,66 @@
+package domain
+
+import "strings"
+
+// TagSource records how a tag got attached to a job.
+const (
+	TagSourceUser = "user"
+	TagSourceAuto = "auto"
+)
+
+// Tag is a label attached to a downloaded video, playlist or channel. Count is
+// only populated when listing the tag catalog; Source is only populated when a
+// tag is returned in the context of a specific job.
+type Tag struct {
+	ID     int64  `json:"id"`
+	Name   string `json:"name"`
+	Source string `json:"source,omitempty"`
+	Count  int    `json:"count,omitempty"`
+}
+
+// maxAutoTags caps how many tags auto-tagging attaches per item so noisy
+// metadata (yt-dlp keyword lists can have dozens of entries) stays manageable.
+const maxAutoTags = 8
+
+// AutoTagsFor derives tags from extracted metadata: the content's categories
+// and channel name, topped up with the first few uploader-supplied keywords.
+// The result is deterministic so re-applying it on metadata refresh is
+// idempotent.
+func AutoTagsFor(metadata Metadata) []string {
+	var candidates []string
+	switch m := metadata.(type) {
+	case *VideoMetadata:
+		candidates = append(candidates, m.Categories...)
+		candidates = append(candidates, m.Channel)
+		candidates = append(candidates, m.Tags...)
+	case *PlaylistMetadata:
+		candidates = append(candidates, m.Channel)
+	case *ChannelMetadata:
+		candidates = append(candidates, m.Channel)
+	}
+
+	tags := make([]string, 0, maxAutoTags)
+	seen := map[string]bool{}
+	for _, c := range candidates {
+		name := NormalizeTagName(c)
+		if name == "" || seen[strings.ToLower(name)] {
+			continue
+		}
+		seen[strings.ToLower(name)] = true
+		tags = append(tags, name)
+		if len(tags) >= maxAutoTags {
+			break
+		}
+	}
+	return tags
+}
+
+// NormalizeTagName trims and length-caps a tag name. Tags are matched
+// case-insensitively by the database, so casing is preserved for display.
+func NormalizeTagName(name string) string {
+	name = strings.Join(strings.Fields(name), " ")
+	if runes := []rune(name); len(runes) > 50 {
+		name = strings.TrimSpace(string(runes[:50]))
+	}
+	return name
+}

--- a/services/backend/internal/repositories/sqlite/db.go
+++ b/services/backend/internal/repositories/sqlite/db.go
@@ -114,5 +114,26 @@ func runMigrations(db *sql.DB) error {
 		}
 	}
 
+	// Migration 2: Tagging tables for databases created before tags existed
+	if _, err := db.Exec(`
+        CREATE TABLE IF NOT EXISTS tags (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE COLLATE NOCASE,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE IF NOT EXISTS job_tags (
+            job_id TEXT NOT NULL,
+            tag_id INTEGER NOT NULL,
+            source TEXT NOT NULL DEFAULT 'user',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (job_id, tag_id),
+            FOREIGN KEY (job_id) REFERENCES jobs (job_id),
+            FOREIGN KEY (tag_id) REFERENCES tags (id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_job_tags_tag_id ON job_tags(tag_id);
+    `); err != nil {
+		return fmt.Errorf("create tag tables: %w", err)
+	}
+
 	return nil
 }

--- a/services/backend/internal/repositories/sqlite/job_repository.go
+++ b/services/backend/internal/repositories/sqlite/job_repository.go
@@ -114,16 +114,22 @@ func (r *JobRepository) GetRecent(limit int) ([]*domain.Job, error) {
 }
 
 func (r *JobRepository) StoreMetadata(jobID string, metadata domain.Metadata) error {
+	var err error
 	switch m := metadata.(type) {
 	case *domain.VideoMetadata:
-		return r.storeVideoMetadata(jobID, m)
+		err = r.storeVideoMetadata(jobID, m)
 	case *domain.PlaylistMetadata:
-		return r.storePlaylistMetadata(jobID, m)
+		err = r.storePlaylistMetadata(jobID, m)
 	case *domain.ChannelMetadata:
-		return r.storeChannelMetadata(jobID, m)
+		err = r.storeChannelMetadata(jobID, m)
 	default:
 		return fmt.Errorf("unsupported metadata type: %T", metadata)
 	}
+	if err != nil {
+		return err
+	}
+	r.applyAutoTags(jobID, metadata)
+	return nil
 }
 
 func (r *JobRepository) storeVideoMetadata(jobID string, metadata *domain.VideoMetadata) error {
@@ -254,9 +260,16 @@ func (r *JobRepository) GetJobWithMetadata(jobID string) (*domain.JobWithMetadat
 		// Continue without metadata
 	}
 
+	tags, err := r.GetTagsForJob(jobID)
+	if err != nil {
+		log.WithError(err).Warnf("Could not retrieve tags for job %s", jobID)
+		tags = nil
+	}
+
 	return &domain.JobWithMetadata{
 		Job:      job,
 		Metadata: metadata,
+		Tags:     tags,
 	}, nil
 }
 
@@ -418,13 +431,20 @@ func (r *JobRepository) getMetadataForJob(jobID string) (domain.Metadata, error)
 	}
 }
 
-func (r *JobRepository) GetMetadataByType(contentType string, page int, limit int, sortBy string, order string) ([]*domain.JobWithMetadata, int, error) {
+func (r *JobRepository) GetMetadataByType(contentType string, opts domain.MetadataQuery) ([]*domain.JobWithMetadata, int, error) {
+	page := opts.Page
+	limit := opts.Limit
+	sortBy := opts.SortBy
+	order := opts.Order
+
 	log.WithFields(log.Fields{
 		"contentType": contentType,
 		"page":        page,
 		"limit":       limit,
 		"sortBy":      sortBy,
 		"order":       order,
+		"search":      opts.Search,
+		"tag":         opts.Tag,
 	}).Debug("Getting metadata by type")
 
 	if page < 1 {
@@ -488,11 +508,40 @@ func (r *JobRepository) GetMetadataByType(contentType string, page int, limit in
 		sortField = "jobs.created_at"
 	}
 
+	// Optional filters. Search matches the title and the channel name stored
+	// inside the metadata JSON; tag narrows to jobs carrying the named tag.
+	// Both are parameterized — only validated identifiers are interpolated.
+	titleColumn := tableName + ".title"
+	if contentType == "channels" {
+		titleColumn = "channels.name"
+	}
+
+	var conditions []string
+	var filterArgs []any
+	if search := strings.TrimSpace(opts.Search); search != "" {
+		pattern := "%" + escapeLike(search) + "%"
+		conditions = append(conditions, `(`+titleColumn+` LIKE ? ESCAPE '\'
+            OR json_extract(`+tableName+`.metadata_json, '$.channel') LIKE ? ESCAPE '\'
+            OR json_extract(`+tableName+`.metadata_json, '$.uploader') LIKE ? ESCAPE '\')`)
+		filterArgs = append(filterArgs, pattern, pattern, pattern)
+	}
+	if tag := strings.TrimSpace(opts.Tag); tag != "" {
+		conditions = append(conditions, `EXISTS (
+            SELECT 1 FROM job_tags jt JOIN tags t ON t.id = jt.tag_id
+            WHERE jt.job_id = jobs.job_id AND t.name = ? COLLATE NOCASE)`)
+		filterArgs = append(filterArgs, tag)
+	}
+
+	whereClause := ""
+	if len(conditions) > 0 {
+		whereClause = " WHERE " + strings.Join(conditions, " AND ")
+	}
+
 	// Get total count first using specific validated table name
 	var totalCount int
-	countQuery := "SELECT COUNT(*) FROM " + tableName + " JOIN jobs ON " + tableName + ".job_id = jobs.job_id"
+	countQuery := "SELECT COUNT(*) FROM " + tableName + " JOIN jobs ON " + tableName + ".job_id = jobs.job_id" + whereClause
 
-	err := r.db.QueryRow(countQuery).Scan(&totalCount)
+	err := r.db.QueryRow(countQuery, filterArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, fmt.Errorf("count %s: %w", contentType, err)
 	}
@@ -502,12 +551,13 @@ func (r *JobRepository) GetMetadataByType(contentType string, page int, limit in
         SELECT jobs.job_id, jobs.url, jobs.status, jobs.progress, jobs.warnings, jobs.created_at, jobs.updated_at, ` +
 		tableName + `.metadata_json
         FROM ` + tableName + `
-        JOIN jobs ON ` + tableName + `.job_id = jobs.job_id
+        JOIN jobs ON ` + tableName + `.job_id = jobs.job_id` +
+		whereClause + `
         ORDER BY ` + sortField + ` ` + orderDirection + `
         LIMIT ? OFFSET ?`
 
 	log.Debugf("Executing download query with limit=%d offset=%d", limit, offset)
-	rows, err := r.db.Query(query, limit, offset)
+	rows, err := r.db.Query(query, append(append([]any{}, filterArgs...), limit, offset)...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("query %s: %w", contentType, err)
 	}
@@ -573,6 +623,10 @@ func (r *JobRepository) GetMetadataByType(contentType string, page int, limit in
 		})
 	}
 
+	if err := r.attachTags(result); err != nil {
+		log.WithError(err).Warn("Failed to attach tags to listing")
+	}
+
 	log.WithFields(log.Fields{
 		"contentType": contentType,
 		"resultCount": len(result),
@@ -580,6 +634,63 @@ func (r *JobRepository) GetMetadataByType(contentType string, page int, limit in
 	}).Debug("Fetched metadata by type")
 
 	return result, totalCount, nil
+}
+
+// escapeLike escapes LIKE wildcards in user input so a search for "100%" does
+// not match everything.
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
+
+// attachTags loads the tags for a page of jobs in one query and assigns them.
+func (r *JobRepository) attachTags(items []*domain.JobWithMetadata) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	ids := make([]any, 0, len(items))
+	placeholders := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.Job == nil {
+			continue
+		}
+		ids = append(ids, item.Job.ID)
+		placeholders = append(placeholders, "?")
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	rows, err := r.db.Query(`
+        SELECT jt.job_id, t.id, t.name, jt.source
+        FROM job_tags jt
+        JOIN tags t ON t.id = jt.tag_id
+        WHERE jt.job_id IN (`+strings.Join(placeholders, ",")+`)
+        ORDER BY jt.source ASC, t.name COLLATE NOCASE ASC`, ids...)
+	if err != nil {
+		return fmt.Errorf("load tags: %w", err)
+	}
+	defer rows.Close()
+
+	tagsByJob := map[string][]domain.Tag{}
+	for rows.Next() {
+		var jobID string
+		var tag domain.Tag
+		if err := rows.Scan(&jobID, &tag.ID, &tag.Name, &tag.Source); err != nil {
+			return fmt.Errorf("scan tag: %w", err)
+		}
+		tagsByJob[jobID] = append(tagsByJob[jobID], tag)
+	}
+
+	for _, item := range items {
+		if item.Job != nil {
+			item.Tags = tagsByJob[item.Job.ID]
+		}
+	}
+	return rows.Err()
 }
 
 func (r *JobRepository) AddVideoToParent(videoJobID, parentJobID, membershipType string) error {

--- a/services/backend/internal/repositories/sqlite/job_repository_tags.go
+++ b/services/backend/internal/repositories/sqlite/job_repository_tags.go
@@ -1,0 +1,184 @@
+package sqlite
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"video-archiver/internal/domain"
+)
+
+// ListTags returns the tag catalog with how many jobs carry each tag, most
+// used first.
+func (r *JobRepository) ListTags() ([]domain.Tag, error) {
+	rows, err := r.db.Query(`
+        SELECT t.id, t.name, COUNT(jt.job_id) as usage_count
+        FROM tags t
+        LEFT JOIN job_tags jt ON jt.tag_id = t.id
+        GROUP BY t.id, t.name
+        ORDER BY usage_count DESC, t.name COLLATE NOCASE ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list tags: %w", err)
+	}
+	defer rows.Close()
+
+	tags := []domain.Tag{}
+	for rows.Next() {
+		var tag domain.Tag
+		if err := rows.Scan(&tag.ID, &tag.Name, &tag.Count); err != nil {
+			return nil, fmt.Errorf("scan tag: %w", err)
+		}
+		tags = append(tags, tag)
+	}
+	return tags, rows.Err()
+}
+
+func (r *JobRepository) GetTagsForJob(jobID string) ([]domain.Tag, error) {
+	rows, err := r.db.Query(`
+        SELECT t.id, t.name, jt.source
+        FROM job_tags jt
+        JOIN tags t ON t.id = jt.tag_id
+        WHERE jt.job_id = ?
+        ORDER BY jt.source ASC, t.name COLLATE NOCASE ASC`, jobID)
+	if err != nil {
+		return nil, fmt.Errorf("get tags for job: %w", err)
+	}
+	defer rows.Close()
+
+	tags := []domain.Tag{}
+	for rows.Next() {
+		var tag domain.Tag
+		if err := rows.Scan(&tag.ID, &tag.Name, &tag.Source); err != nil {
+			return nil, fmt.Errorf("scan job tag: %w", err)
+		}
+		tags = append(tags, tag)
+	}
+	return tags, rows.Err()
+}
+
+// AddTagsToJob attaches the named tags to a job, creating missing tags on the
+// fly. Names are matched case-insensitively; already-attached tags are left
+// untouched (a user tag is not downgraded to auto). Returns the job's full tag
+// list afterwards.
+func (r *JobRepository) AddTagsToJob(jobID string, names []string, source string) ([]domain.Tag, error) {
+	if source != domain.TagSourceAuto {
+		source = domain.TagSourceUser
+	}
+
+	for _, name := range names {
+		name = domain.NormalizeTagName(name)
+		if name == "" {
+			continue
+		}
+		tagID, err := r.ensureTag(name)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := r.db.Exec(`
+            INSERT OR IGNORE INTO job_tags (job_id, tag_id, source)
+            VALUES (?, ?, ?)`, jobID, tagID, source); err != nil {
+			return nil, fmt.Errorf("attach tag %q: %w", name, err)
+		}
+	}
+	return r.GetTagsForJob(jobID)
+}
+
+// ensureTag returns the ID of the named tag, creating it if needed.
+func (r *JobRepository) ensureTag(name string) (int64, error) {
+	var id int64
+	err := r.db.QueryRow(`SELECT id FROM tags WHERE name = ? COLLATE NOCASE`, name).Scan(&id)
+	if err == nil {
+		return id, nil
+	}
+	if err != sql.ErrNoRows {
+		return 0, fmt.Errorf("look up tag %q: %w", name, err)
+	}
+
+	res, err := r.db.Exec(`INSERT INTO tags (name) VALUES (?)`, name)
+	if err != nil {
+		return 0, fmt.Errorf("create tag %q: %w", name, err)
+	}
+	return res.LastInsertId()
+}
+
+// RemoveTagFromJob detaches a tag from a job and removes the tag entirely once
+// nothing references it, so the catalog does not fill with orphans.
+func (r *JobRepository) RemoveTagFromJob(jobID string, tagID int64) error {
+	if _, err := r.db.Exec(`DELETE FROM job_tags WHERE job_id = ? AND tag_id = ?`, jobID, tagID); err != nil {
+		return fmt.Errorf("remove tag from job: %w", err)
+	}
+	if _, err := r.db.Exec(`
+        DELETE FROM tags WHERE id = ?
+        AND NOT EXISTS (SELECT 1 FROM job_tags WHERE tag_id = ?)`, tagID, tagID); err != nil {
+		return fmt.Errorf("prune orphan tag: %w", err)
+	}
+	return nil
+}
+
+// applyAutoTags derives and attaches automatic tags for freshly stored
+// metadata. Failures are logged rather than propagated: tagging must never
+// fail a download.
+func (r *JobRepository) applyAutoTags(jobID string, metadata domain.Metadata) {
+	names := domain.AutoTagsFor(metadata)
+	if len(names) == 0 {
+		return
+	}
+	if _, err := r.AddTagsToJob(jobID, names, domain.TagSourceAuto); err != nil {
+		log.WithError(err).WithField("jobID", jobID).Warn("Failed to apply auto tags")
+	}
+}
+
+// BackfillAutoTags applies auto-tagging to every item that was downloaded
+// before tagging existed. It is idempotent and safe to run at every startup.
+func (r *JobRepository) BackfillAutoTags() error {
+	jobs, err := r.GetAllJobsWithMetadata()
+	if err != nil {
+		return fmt.Errorf("load jobs for tag backfill: %w", err)
+	}
+	for _, jwm := range jobs {
+		if jwm == nil || jwm.Job == nil || jwm.Metadata == nil {
+			continue
+		}
+		r.applyAutoTags(jwm.Job.ID, jwm.Metadata)
+	}
+	return nil
+}
+
+// DeleteJob removes a job and everything referencing it: metadata records,
+// playlist/channel memberships and tag assignments. Orphaned tags are pruned
+// afterwards. Files on disk are the caller's responsibility.
+func (r *JobRepository) DeleteJob(jobID string) error {
+	statements := []string{
+		`DELETE FROM videos WHERE job_id = ?`,
+		`DELETE FROM playlists WHERE job_id = ?`,
+		`DELETE FROM channels WHERE job_id = ?`,
+		`DELETE FROM video_memberships WHERE video_job_id = ? OR parent_job_id = ?`,
+		`DELETE FROM job_tags WHERE job_id = ?`,
+		`DELETE FROM jobs WHERE job_id = ?`,
+	}
+
+	tx, err := r.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin delete: %w", err)
+	}
+	defer tx.Rollback()
+
+	for _, stmt := range statements {
+		args := []any{jobID}
+		if strings.Contains(stmt, "OR parent_job_id") {
+			args = append(args, jobID)
+		}
+		if _, err := tx.Exec(stmt, args...); err != nil {
+			return fmt.Errorf("delete job %s: %w", jobID, err)
+		}
+	}
+	if _, err := tx.Exec(`
+        DELETE FROM tags WHERE NOT EXISTS (
+            SELECT 1 FROM job_tags WHERE job_tags.tag_id = tags.id
+        )`); err != nil {
+		return fmt.Errorf("prune orphan tags: %w", err)
+	}
+
+	return tx.Commit()
+}

--- a/services/backend/internal/repositories/sqlite/job_repository_tags_test.go
+++ b/services/backend/internal/repositories/sqlite/job_repository_tags_test.go
@@ -1,0 +1,229 @@
+package sqlite
+
+import (
+	"testing"
+	"video-archiver/internal/domain"
+	"video-archiver/internal/testutil"
+)
+
+func tagNames(tags []domain.Tag) []string {
+	names := make([]string, 0, len(tags))
+	for _, t := range tags {
+		names = append(names, t.Name)
+	}
+	return names
+}
+
+func containsName(tags []domain.Tag, name string) bool {
+	for _, t := range tags {
+		if t.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestJobRepository_AddAndGetTags(t *testing.T) {
+	db := testutil.CreateTestDB(t)
+	defer db.Close()
+
+	repo := NewJobRepository(db)
+	job := testutil.CreateTestJob("job-1", "https://youtube.com/watch?v=test")
+	if err := repo.Create(job); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	tags, err := repo.AddTagsToJob("job-1", []string{"music", "Favorites"}, domain.TagSourceUser)
+	if err != nil {
+		t.Fatalf("AddTagsToJob() error = %v", err)
+	}
+	if len(tags) != 2 {
+		t.Fatalf("AddTagsToJob() returned %d tags, want 2: %v", len(tags), tagNames(tags))
+	}
+
+	// Re-adding with different casing must not create duplicates.
+	tags, err = repo.AddTagsToJob("job-1", []string{"MUSIC"}, domain.TagSourceUser)
+	if err != nil {
+		t.Fatalf("AddTagsToJob() error = %v", err)
+	}
+	if len(tags) != 2 {
+		t.Errorf("case-insensitive re-add created duplicate: %v", tagNames(tags))
+	}
+}
+
+func TestJobRepository_RemoveTagPrunesOrphans(t *testing.T) {
+	db := testutil.CreateTestDB(t)
+	defer db.Close()
+
+	repo := NewJobRepository(db)
+	job := testutil.CreateTestJob("job-1", "https://youtube.com/watch?v=test")
+	repo.Create(job)
+
+	tags, err := repo.AddTagsToJob("job-1", []string{"solo-tag"}, domain.TagSourceUser)
+	if err != nil {
+		t.Fatalf("AddTagsToJob() error = %v", err)
+	}
+
+	if err := repo.RemoveTagFromJob("job-1", tags[0].ID); err != nil {
+		t.Fatalf("RemoveTagFromJob() error = %v", err)
+	}
+
+	all, err := repo.ListTags()
+	if err != nil {
+		t.Fatalf("ListTags() error = %v", err)
+	}
+	if containsName(all, "solo-tag") {
+		t.Errorf("orphaned tag was not pruned: %v", tagNames(all))
+	}
+}
+
+func TestJobRepository_AutoTagsOnStoreMetadata(t *testing.T) {
+	db := testutil.CreateTestDB(t)
+	defer db.Close()
+
+	repo := NewJobRepository(db)
+	job := testutil.CreateTestJob("job-1", "https://youtube.com/watch?v=test")
+	repo.Create(job)
+
+	// Test metadata has Categories=[Entertainment], Channel=Test Channel,
+	// Tags=[tag1 tag2].
+	if err := repo.StoreMetadata("job-1", testutil.CreateTestVideoMetadata()); err != nil {
+		t.Fatalf("StoreMetadata() error = %v", err)
+	}
+
+	tags, err := repo.GetTagsForJob("job-1")
+	if err != nil {
+		t.Fatalf("GetTagsForJob() error = %v", err)
+	}
+	for _, want := range []string{"Entertainment", "Test Channel", "tag1", "tag2"} {
+		if !containsName(tags, want) {
+			t.Errorf("auto tags missing %q, got: %v", want, tagNames(tags))
+		}
+	}
+	for _, tag := range tags {
+		if tag.Source != domain.TagSourceAuto {
+			t.Errorf("tag %q has source %q, want auto", tag.Name, tag.Source)
+		}
+	}
+
+	// Storing metadata again must not duplicate tags.
+	before := len(tags)
+	if err := repo.StoreMetadata("job-1", testutil.CreateTestVideoMetadata()); err != nil {
+		t.Fatalf("StoreMetadata() second call error = %v", err)
+	}
+	tags, _ = repo.GetTagsForJob("job-1")
+	if len(tags) != before {
+		t.Errorf("re-storing metadata changed tag count: %d -> %d", before, len(tags))
+	}
+}
+
+func TestJobRepository_SearchAndTagFilter(t *testing.T) {
+	db := testutil.CreateTestDB(t)
+	defer db.Close()
+
+	repo := NewJobRepository(db)
+
+	makeVideo := func(id, title, channel string) {
+		job := testutil.CreateTestJob(id, "https://youtube.com/watch?v="+id)
+		repo.Create(job)
+		meta := testutil.CreateTestVideoMetadata()
+		meta.Title = title
+		meta.Channel = channel
+		meta.Tags = nil
+		meta.Categories = nil
+		repo.StoreMetadata(id, meta)
+	}
+
+	makeVideo("v1", "Golang Tutorial", "Tech Channel")
+	makeVideo("v2", "Cooking Pasta 100%", "Food Network")
+	makeVideo("v3", "Advanced golang patterns", "Tech Channel")
+
+	query := func(search, tag string) ([]*domain.JobWithMetadata, int) {
+		items, total, err := repo.GetMetadataByType("videos", domain.MetadataQuery{
+			Page: 1, Limit: 20, SortBy: "created_at", Order: "desc",
+			Search: search, Tag: tag,
+		})
+		if err != nil {
+			t.Fatalf("GetMetadataByType(search=%q tag=%q) error = %v", search, tag, err)
+		}
+		return items, total
+	}
+
+	if _, total := query("golang", ""); total != 2 {
+		t.Errorf("search 'golang' total = %d, want 2", total)
+	}
+	// Search must match the channel too.
+	if _, total := query("food network", ""); total != 1 {
+		t.Errorf("search 'food network' total = %d, want 1", total)
+	}
+	// LIKE wildcards in the query must be treated literally.
+	if _, total := query("100%", ""); total != 1 {
+		t.Errorf("search '100%%' total = %d, want 1", total)
+	}
+	if _, total := query("no-such-video", ""); total != 0 {
+		t.Errorf("search 'no-such-video' total = %d, want 0", total)
+	}
+
+	// Tag filter: only v1 gets the user tag; auto channel tags exist too.
+	if _, err := repo.AddTagsToJob("v1", []string{"watch-later"}, domain.TagSourceUser); err != nil {
+		t.Fatalf("AddTagsToJob() error = %v", err)
+	}
+	items, total := query("", "watch-later")
+	if total != 1 || len(items) != 1 {
+		t.Fatalf("tag filter total = %d (items %d), want 1", total, len(items))
+	}
+	if items[0].Job.ID != "v1" {
+		t.Errorf("tag filter returned job %s, want v1", items[0].Job.ID)
+	}
+	if !containsName(items[0].Tags, "watch-later") {
+		t.Errorf("listing did not attach tags: %v", tagNames(items[0].Tags))
+	}
+
+	// Combined search + tag.
+	if _, total := query("golang", "watch-later"); total != 1 {
+		t.Errorf("combined search+tag total = %d, want 1", total)
+	}
+
+	// Auto tag from channel should match case-insensitively.
+	if _, total := query("", "tech channel"); total != 2 {
+		t.Errorf("tag filter 'tech channel' total = %d, want 2", total)
+	}
+}
+
+func TestJobRepository_DeleteJob(t *testing.T) {
+	db := testutil.CreateTestDB(t)
+	defer db.Close()
+
+	repo := NewJobRepository(db)
+
+	video := testutil.CreateTestJob("video-1", "https://youtube.com/watch?v=video-1")
+	repo.Create(video)
+	repo.StoreMetadata("video-1", testutil.CreateTestVideoMetadata())
+
+	parent := testutil.CreateTestJob("parent-1", "https://youtube.com/playlist?list=test")
+	repo.Create(parent)
+	repo.StoreMetadata("parent-1", testutil.CreateTestPlaylistMetadata())
+	repo.AddVideoToParent("video-1", "parent-1", "playlist")
+
+	if err := repo.DeleteJob("video-1"); err != nil {
+		t.Fatalf("DeleteJob() error = %v", err)
+	}
+
+	if _, err := repo.GetByID("video-1"); err == nil {
+		t.Error("job row still exists after DeleteJob()")
+	}
+	if count, _ := repo.CountVideos(); count != 0 {
+		t.Errorf("video metadata still exists after DeleteJob(): count = %d", count)
+	}
+	if videos, _ := repo.GetVideosForParent("parent-1"); len(videos) != 0 {
+		t.Errorf("membership still exists after DeleteJob(): %d", len(videos))
+	}
+	if tags, _ := repo.GetTagsForJob("video-1"); len(tags) != 0 {
+		t.Errorf("tags still attached after DeleteJob(): %v", tagNames(tags))
+	}
+
+	// The parent must remain untouched.
+	if _, err := repo.GetByID("parent-1"); err != nil {
+		t.Errorf("parent job was deleted too: %v", err)
+	}
+}

--- a/services/backend/internal/repositories/sqlite/job_repository_test.go
+++ b/services/backend/internal/repositories/sqlite/job_repository_test.go
@@ -370,7 +370,12 @@ func TestJobRepository_GetMetadataByType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			items, total, err := repo.GetMetadataByType(tt.contentType, tt.page, tt.limit, "created_at", "desc")
+			items, total, err := repo.GetMetadataByType(tt.contentType, domain.MetadataQuery{
+				Page:   tt.page,
+				Limit:  tt.limit,
+				SortBy: "created_at",
+				Order:  "desc",
+			})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetMetadataByType() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/services/backend/internal/services/download/service.go
+++ b/services/backend/internal/services/download/service.go
@@ -16,6 +16,7 @@ import (
 	"time"
 	"video-archiver/internal/domain"
 	"video-archiver/internal/services/metadata"
+	"video-archiver/internal/services/tools"
 )
 
 type Config struct {
@@ -132,6 +133,61 @@ func (s *Service) CancelJob(id string) error {
 
 	log.WithField("job_id", id).Info("Download job cancelled")
 	return nil
+}
+
+// DeleteJob removes a download from the library: the database records and, for
+// videos, the media file on disk. A still-running job is cancelled first.
+// Deleting a playlist or channel removes only the parent record — the videos it
+// contains remain individually downloaded jobs.
+func (s *Service) DeleteJob(id string) error {
+	jwm, err := s.jobs.GetJobWithMetadata(id)
+	if err != nil {
+		return fmt.Errorf("get job: %w", err)
+	}
+	if jwm == nil || jwm.Job == nil {
+		return fmt.Errorf("job not found")
+	}
+
+	if jwm.Job.Status == domain.JobStatusPending || jwm.Job.Status == domain.JobStatusInProgress {
+		if err := s.CancelJob(id); err != nil {
+			log.WithError(err).WithField("job_id", id).Warn("Failed to cancel job before deletion")
+		}
+	}
+
+	if meta, ok := jwm.Metadata.(*domain.VideoMetadata); ok && meta != nil {
+		s.removeVideoFiles(meta)
+	}
+
+	if err := s.jobs.DeleteJob(id); err != nil {
+		return fmt.Errorf("delete job records: %w", err)
+	}
+
+	log.WithField("job_id", id).Info("Download job deleted")
+	return nil
+}
+
+// removeVideoFiles deletes a video's media file and its yt-dlp sidecar files
+// (.info.json etc.) from disk. Missing files are not an error — the library
+// record should be removable even if the file is already gone.
+func (s *Service) removeVideoFiles(meta *domain.VideoMetadata) {
+	path, err := tools.ResolveVideoFile(s.config.DownloadPath, meta)
+	if err != nil {
+		log.WithField("title", meta.Title).Debug("No media file found to delete")
+		return
+	}
+
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		log.WithError(err).WithField("path", path).Warn("Failed to delete video file")
+	} else {
+		log.WithField("path", path).Info("Deleted video file")
+	}
+
+	stem := strings.TrimSuffix(path, filepath.Ext(path))
+	for _, sidecar := range []string{stem + ".info.json", stem + ".description", stem + ".webp", stem + ".jpg"} {
+		if err := os.Remove(sidecar); err == nil {
+			log.WithField("path", sidecar).Debug("Deleted sidecar file")
+		}
+	}
 }
 
 func (s *Service) GetRepository() domain.JobRepository {
@@ -447,8 +503,6 @@ func (s *Service) downloadPlaylistOrChannel(ctx context.Context, job domain.Job,
 			log.Debugf("Extractor %s has %d videos: %v", extractor, len(ids), ids)
 		}
 	}
-
-	// TODO: Determine the membership type based on metadata type
 
 	// Scan for downloaded video metadata files in the output directory
 	// Note: outputPath contains yt-dlp template variables like %(uploader)s, so we need to use the actual download path

--- a/services/backend/internal/services/tools/service.go
+++ b/services/backend/internal/services/tools/service.go
@@ -187,6 +187,33 @@ func (s *Service) CancelJob(id string) error {
 	return nil
 }
 
+// DeleteJob removes a finished job's record and its output file from the
+// processed directory. Running or queued jobs must be cancelled instead.
+func (s *Service) DeleteJob(id string) error {
+	job, err := s.toolsRepo.GetByID(id)
+	if err != nil {
+		return fmt.Errorf("get job: %w", err)
+	}
+	if job == nil {
+		return fmt.Errorf("job not found")
+	}
+	if job.Status == domain.ToolsJobStatusPending || job.Status == domain.ToolsJobStatusProcessing {
+		return fmt.Errorf("cannot delete a %s job, cancel it first", job.Status)
+	}
+
+	if path, err := s.ResolveOutputFile(job); err == nil {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			log.WithError(err).WithField("path", path).Warn("Failed to delete tools output file")
+		}
+	}
+
+	if err := s.toolsRepo.Delete(id); err != nil {
+		return fmt.Errorf("delete job record: %w", err)
+	}
+	log.WithField("job_id", id).Info("Tools job deleted")
+	return nil
+}
+
 func (s *Service) worker() {
 	defer s.wg.Done()
 	for {

--- a/services/backend/internal/testutil/helpers.go
+++ b/services/backend/internal/testutil/helpers.go
@@ -63,6 +63,22 @@ func CreateTestDB(t *testing.T) *sql.DB {
 		FOREIGN KEY(parent_job_id) REFERENCES jobs(job_id),
 		UNIQUE(video_job_id, parent_job_id)
 	);
+
+	CREATE TABLE IF NOT EXISTS tags (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL UNIQUE COLLATE NOCASE,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE TABLE IF NOT EXISTS job_tags (
+		job_id TEXT NOT NULL,
+		tag_id INTEGER NOT NULL,
+		source TEXT NOT NULL DEFAULT 'user',
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (job_id, tag_id),
+		FOREIGN KEY (job_id) REFERENCES jobs (job_id),
+		FOREIGN KEY (tag_id) REFERENCES tags (id)
+	);
 	`
 
 	if _, err := db.Exec(schema); err != nil {
@@ -183,6 +199,7 @@ type MockJobRepository struct {
 	metadata map[string]domain.Metadata
 	parents  map[string][]*domain.JobWithMetadata
 	videos   map[string][]*domain.JobWithMetadata
+	tags     map[string][]domain.Tag
 }
 
 // NewMockJobRepository creates a new mock repository
@@ -192,6 +209,7 @@ func NewMockJobRepository() *MockJobRepository {
 		metadata: make(map[string]domain.Metadata),
 		parents:  make(map[string][]*domain.JobWithMetadata),
 		videos:   make(map[string][]*domain.JobWithMetadata),
+		tags:     make(map[string][]domain.Tag),
 	}
 }
 
@@ -306,7 +324,7 @@ func (m *MockJobRepository) CountChannels() (int, error) {
 	return count, nil
 }
 
-func (m *MockJobRepository) GetMetadataByType(contentType string, page int, limit int, sortBy string, order string) ([]*domain.JobWithMetadata, int, error) {
+func (m *MockJobRepository) GetMetadataByType(contentType string, opts domain.MetadataQuery) ([]*domain.JobWithMetadata, int, error) {
 	result := make([]*domain.JobWithMetadata, 0)
 	for id, meta := range m.metadata {
 		var matches bool
@@ -353,4 +371,67 @@ func (m *MockJobRepository) GetVideosForParent(parentJobID string) ([]*domain.Jo
 
 func (m *MockJobRepository) GetParentsForVideo(videoJobID string) ([]*domain.JobWithMetadata, error) {
 	return m.parents[videoJobID], nil
+}
+
+func (m *MockJobRepository) DeleteJob(jobID string) error {
+	delete(m.jobs, jobID)
+	delete(m.metadata, jobID)
+	delete(m.parents, jobID)
+	delete(m.videos, jobID)
+	delete(m.tags, jobID)
+	return nil
+}
+
+func (m *MockJobRepository) ListTags() ([]domain.Tag, error) {
+	counts := map[string]int{}
+	for _, tags := range m.tags {
+		for _, tag := range tags {
+			counts[tag.Name]++
+		}
+	}
+	result := make([]domain.Tag, 0, len(counts))
+	var id int64 = 1
+	for name, count := range counts {
+		result = append(result, domain.Tag{ID: id, Name: name, Count: count})
+		id++
+	}
+	return result, nil
+}
+
+func (m *MockJobRepository) GetTagsForJob(jobID string) ([]domain.Tag, error) {
+	return m.tags[jobID], nil
+}
+
+func (m *MockJobRepository) AddTagsToJob(jobID string, names []string, source string) ([]domain.Tag, error) {
+	existing := map[string]bool{}
+	for _, tag := range m.tags[jobID] {
+		existing[tag.Name] = true
+	}
+	for _, name := range names {
+		if name == "" || existing[name] {
+			continue
+		}
+		existing[name] = true
+		m.tags[jobID] = append(m.tags[jobID], domain.Tag{
+			ID:     int64(len(m.tags[jobID]) + 1),
+			Name:   name,
+			Source: source,
+		})
+	}
+	return m.tags[jobID], nil
+}
+
+func (m *MockJobRepository) RemoveTagFromJob(jobID string, tagID int64) error {
+	tags := m.tags[jobID]
+	for i, tag := range tags {
+		if tag.ID == tagID {
+			m.tags[jobID] = append(tags[:i], tags[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+func (m *MockJobRepository) BackfillAutoTags() error {
+	return nil
 }

--- a/web/components/confirm-dialog.tsx
+++ b/web/components/confirm-dialog.tsx
@@ -1,0 +1,79 @@
+import { Loader2 } from 'lucide-react'
+
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog'
+
+interface ConfirmDialogProps {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    title: string
+    description: string
+    confirmLabel?: string
+    /** Called when the user confirms. The dialog closes when it resolves. */
+    onConfirm: () => Promise<void> | void
+}
+
+/**
+ * Confirmation dialog for destructive actions. Keeps the dialog open with a
+ * spinner while the confirm action runs, so slow deletions give feedback
+ * instead of appearing to do nothing.
+ */
+export function ConfirmDialog({
+    open,
+    onOpenChange,
+    title,
+    description,
+    confirmLabel = 'Delete',
+    onConfirm,
+}: ConfirmDialogProps) {
+    const [busy, setBusy] = useState(false)
+
+    const handleConfirm = async () => {
+        setBusy(true)
+        try {
+            await onConfirm()
+            onOpenChange(false)
+        } finally {
+            setBusy(false)
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={(o) => !busy && onOpenChange(o)}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>{title}</DialogTitle>
+                    <DialogDescription>{description}</DialogDescription>
+                </DialogHeader>
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                        disabled={busy}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        variant="destructive"
+                        onClick={handleConfirm}
+                        disabled={busy}
+                    >
+                        {busy && (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        )}
+                        {confirmLabel}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/web/components/downloads/DownloadsContent.tsx
+++ b/web/components/downloads/DownloadsContent.tsx
@@ -8,11 +8,13 @@ import { SERVER_URL } from '@/lib/env'
 import { ensureMinimumDelay } from '@/lib/loading'
 
 import { ChannelsGrid } from '@/components/downloads/ChannelsGrid'
+import { LibraryFilters } from '@/components/downloads/LibraryFilters'
 import { PaginationControls } from '@/components/downloads/PaginationControls'
 import { PlaylistsGrid } from '@/components/downloads/PlaylistsGrid'
 import { SortControls } from '@/components/downloads/SortControls'
 import { VideosGrid } from '@/components/downloads/VideosGrid'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -57,18 +59,22 @@ export default function DownloadsContent() {
     const pageSize = Number(searchParams.get('limit')) || 20
     const sortBy = searchParams.get('sort_by') || 'created_at'
     const order = (searchParams.get('order') || 'desc') as 'asc' | 'desc'
+    const search = searchParams.get('search') || ''
+    const tag = searchParams.get('tag') || ''
 
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
     const [data, setData] = useState<PaginatedResponse | null>(null)
 
-    // Update URL query params
+    // Update URL query params; empty values remove the param
     const updateUrlParams = (params: Record<string, string | number>) => {
         const newParams = new URLSearchParams(searchParams)
 
         Object.entries(params).forEach(([key, value]) => {
-            if (value !== undefined && value !== null) {
+            if (value !== undefined && value !== null && value !== '') {
                 newParams.set(key, String(value))
+            } else {
+                newParams.delete(key)
             }
         })
 
@@ -78,6 +84,15 @@ export default function DownloadsContent() {
     // Handle tab change
     const handleTabChange = (value: string) => {
         updateUrlParams({ type: value, page: 1 })
+    }
+
+    // Handle search and tag filter changes
+    const handleSearchChange = (value: string) => {
+        updateUrlParams({ search: value, page: 1 })
+    }
+
+    const handleTagChange = (value: string) => {
+        updateUrlParams({ tag: value, page: 1 })
     }
 
     // Handle sort change
@@ -110,6 +125,12 @@ export default function DownloadsContent() {
                 url.searchParams.append('limit', String(pageSize))
                 url.searchParams.append('sort_by', sortBy)
                 url.searchParams.append('order', order)
+                if (search) {
+                    url.searchParams.append('search', search)
+                }
+                if (tag) {
+                    url.searchParams.append('tag', tag)
+                }
 
                 const response = await fetch(url.toString())
 
@@ -160,7 +181,7 @@ export default function DownloadsContent() {
         }
 
         fetchDownloads()
-    }, [activeTab, currentPage, pageSize, sortBy, order])
+    }, [activeTab, currentPage, pageSize, sortBy, order, search, tag])
 
     const renderLoadingState = () => (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -219,6 +240,13 @@ export default function DownloadsContent() {
                     )}
                 </div>
 
+                <LibraryFilters
+                    search={search}
+                    tag={tag}
+                    onSearchChange={handleSearchChange}
+                    onTagChange={handleTagChange}
+                />
+
                 {error && (
                     <Alert variant="destructive" className="mb-6">
                         <AlertCircle className="h-4 w-4" />
@@ -229,6 +257,24 @@ export default function DownloadsContent() {
 
                 {loading ? (
                     renderLoadingState()
+                ) : !data?.items.length && (search || tag) ? (
+                    <div className="text-muted-foreground py-12 text-center">
+                        <p className="mb-4">
+                            No {activeTab} match your filters
+                        </p>
+                        <Button
+                            variant="outline"
+                            onClick={() =>
+                                updateUrlParams({
+                                    search: '',
+                                    tag: '',
+                                    page: 1,
+                                })
+                            }
+                        >
+                            Clear filters
+                        </Button>
+                    </div>
                 ) : (
                     <>
                         <TabsContent value="videos">

--- a/web/components/downloads/LibraryFilters.tsx
+++ b/web/components/downloads/LibraryFilters.tsx
@@ -1,0 +1,146 @@
+import { listTags } from '@/services/libraryApi'
+import { Tag } from '@/types'
+import { ChevronDown, Search, TagIcon, X } from 'lucide-react'
+
+import { useEffect, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+
+interface LibraryFiltersProps {
+    search: string
+    tag: string
+    onSearchChange: (value: string) => void
+    onTagChange: (value: string) => void
+}
+
+const SEARCH_DEBOUNCE_MS = 300
+
+/**
+ * Search box and tag filter for the downloads library. Search input is
+ * debounced before it reaches the URL (and triggers a fetch); the tag list is
+ * loaded from the backend catalog with usage counts.
+ */
+export function LibraryFilters({
+    search,
+    tag,
+    onSearchChange,
+    onTagChange,
+}: LibraryFiltersProps) {
+    const [draft, setDraft] = useState(search)
+    const [tags, setTags] = useState<Tag[]>([])
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    // Keep the input in sync when the URL changes from elsewhere
+    // (e.g. back navigation).
+    useEffect(() => {
+        setDraft(search)
+    }, [search])
+
+    useEffect(() => {
+        listTags()
+            .then(setTags)
+            .catch((err) => console.error('Failed to load tags:', err))
+    }, [])
+
+    const handleInput = (value: string) => {
+        setDraft(value)
+        if (debounceRef.current) {
+            clearTimeout(debounceRef.current)
+        }
+        debounceRef.current = setTimeout(
+            () => onSearchChange(value.trim()),
+            SEARCH_DEBOUNCE_MS
+        )
+    }
+
+    const clearSearch = () => {
+        if (debounceRef.current) {
+            clearTimeout(debounceRef.current)
+        }
+        setDraft('')
+        onSearchChange('')
+    }
+
+    return (
+        <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-center">
+            <div className="relative flex-1 sm:max-w-sm">
+                <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+                <Input
+                    value={draft}
+                    onChange={(e) => handleInput(e.target.value)}
+                    placeholder="Search by title or channel…"
+                    className="pr-8 pl-9"
+                    aria-label="Search downloads"
+                />
+                {draft && (
+                    <button
+                        type="button"
+                        aria-label="Clear search"
+                        onClick={clearSearch}
+                        className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2.5 -translate-y-1/2"
+                    >
+                        <X className="h-4 w-4" />
+                    </button>
+                )}
+            </div>
+
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button
+                        variant={tag ? 'secondary' : 'outline'}
+                        className="flex items-center gap-2"
+                    >
+                        <TagIcon className="h-4 w-4" />
+                        <span className="max-w-32 truncate">
+                            {tag || 'All tags'}
+                        </span>
+                        <ChevronDown className="h-4 w-4" />
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                    align="start"
+                    className="max-h-80 w-56 overflow-y-auto"
+                >
+                    <DropdownMenuLabel>Filter by tag</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                        className={!tag ? 'bg-accent' : ''}
+                        onClick={() => onTagChange('')}
+                    >
+                        All tags
+                    </DropdownMenuItem>
+                    {tags.map((t) => (
+                        <DropdownMenuItem
+                            key={t.id}
+                            className={
+                                tag.toLowerCase() === t.name.toLowerCase()
+                                    ? 'bg-accent'
+                                    : ''
+                            }
+                            onClick={() => onTagChange(t.name)}
+                        >
+                            <span className="flex-1 truncate">{t.name}</span>
+                            <span className="text-muted-foreground ml-2 text-xs">
+                                {t.count}
+                            </span>
+                        </DropdownMenuItem>
+                    ))}
+                    {tags.length === 0 && (
+                        <DropdownMenuItem disabled>
+                            No tags yet
+                        </DropdownMenuItem>
+                    )}
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </div>
+    )
+}

--- a/web/components/downloads/VideosGrid.tsx
+++ b/web/components/downloads/VideosGrid.tsx
@@ -130,6 +130,24 @@ export function VideosGrid({ items }: VideosGridProps) {
                                         : 'Unknown size'}
                                 </Badge>
                             </div>
+                            {item.tags && item.tags.length > 0 && (
+                                <div className="mt-2 flex items-center gap-1 overflow-hidden">
+                                    {item.tags.slice(0, 3).map((tag) => (
+                                        <Badge
+                                            key={tag.id}
+                                            variant="secondary"
+                                            className="max-w-28 truncate text-xs"
+                                        >
+                                            {tag.name}
+                                        </Badge>
+                                    ))}
+                                    {item.tags.length > 3 && (
+                                        <span className="text-muted-foreground text-xs">
+                                            +{item.tags.length - 3}
+                                        </span>
+                                    )}
+                                </div>
+                            )}
                         </CardContent>
                     </Card>
                 )

--- a/web/components/tag-editor.tsx
+++ b/web/components/tag-editor.tsx
@@ -1,0 +1,127 @@
+import { addJobTags, removeJobTag } from '@/services/libraryApi'
+import { Tag } from '@/types'
+import { Plus, Sparkles, X } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { useState } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+interface TagEditorProps {
+    jobId: string
+    tags: Tag[]
+    onChange: (tags: Tag[]) => void
+}
+
+/**
+ * Editable tag list for a download. Auto-generated tags (from the video's
+ * category, channel and keywords) are marked with a sparkle; user tags can be
+ * added with the input and any tag can be removed.
+ */
+export function TagEditor({ jobId, tags, onChange }: TagEditorProps) {
+    const [input, setInput] = useState('')
+    const [busy, setBusy] = useState(false)
+
+    const addTag = async () => {
+        const name = input.trim()
+        if (!name) return
+        setBusy(true)
+        try {
+            const updated = await addJobTags(jobId, [name])
+            onChange(updated)
+            setInput('')
+        } catch (err) {
+            toast.error(
+                err instanceof Error ? err.message : 'Failed to add tag'
+            )
+        } finally {
+            setBusy(false)
+        }
+    }
+
+    const removeTag = async (tag: Tag) => {
+        try {
+            await removeJobTag(jobId, tag.id)
+            onChange(tags.filter((t) => t.id !== tag.id))
+        } catch (err) {
+            toast.error(
+                err instanceof Error ? err.message : 'Failed to remove tag'
+            )
+        }
+    }
+
+    return (
+        <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+                {tags.length === 0 && (
+                    <p className="text-muted-foreground text-sm">
+                        No tags yet — add one below
+                    </p>
+                )}
+                {tags.map((tag) => (
+                    <Badge
+                        key={tag.id}
+                        variant={
+                            tag.source === 'auto' ? 'secondary' : 'default'
+                        }
+                        className="gap-1 pr-1 text-xs"
+                    >
+                        {tag.source === 'auto' && (
+                            <TooltipProvider>
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <Sparkles className="h-3 w-3" />
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                        <p>Added automatically from metadata</p>
+                                    </TooltipContent>
+                                </Tooltip>
+                            </TooltipProvider>
+                        )}
+                        {tag.name}
+                        <button
+                            type="button"
+                            aria-label={`Remove tag ${tag.name}`}
+                            className="hover:bg-background/30 ml-0.5 rounded-full p-0.5"
+                            onClick={() => removeTag(tag)}
+                        >
+                            <X className="h-3 w-3" />
+                        </button>
+                    </Badge>
+                ))}
+            </div>
+            <div className="flex gap-2">
+                <Input
+                    value={input}
+                    onChange={(e) => setInput(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                            e.preventDefault()
+                            addTag()
+                        }
+                    }}
+                    placeholder="Add a tag…"
+                    className="h-8 text-sm"
+                    maxLength={50}
+                />
+                <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={addTag}
+                    disabled={busy || !input.trim()}
+                >
+                    <Plus className="h-4 w-4" />
+                    Add
+                </Button>
+            </div>
+        </div>
+    )
+}

--- a/web/components/tools/ProcessedResults.tsx
+++ b/web/components/tools/ProcessedResults.tsx
@@ -1,10 +1,17 @@
-import { listToolJobs, toolOutputUrl } from '@/services/toolsApi'
+import {
+    deleteToolJob,
+    listToolJobs,
+    toolOutputPreviewUrl,
+    toolOutputUrl,
+} from '@/services/toolsApi'
 import useWebSocketStore from '@/services/websocket'
 import { ToolsJob } from '@/types'
-import { Download, FileVideo } from 'lucide-react'
+import { Download, FileVideo, Play, Trash2, X } from 'lucide-react'
+import { toast } from 'sonner'
 
 import { useCallback, useEffect, useState } from 'react'
 
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -37,11 +44,19 @@ function operationLabel(op: string): string {
     return op.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
+const audioExtensions = ['mp3', 'aac', 'flac', 'wav', 'ogg', 'm4a']
+
+function fileKind(filename: string): 'audio' | 'video' {
+    const ext = filename.split('.').pop()?.toLowerCase() ?? ''
+    return audioExtensions.includes(ext) ? 'audio' : 'video'
+}
+
 /**
  * ProcessedResults lists the outputs of completed tool jobs and lets the user
- * download them. It is backed by the API (so it survives page reloads) and
- * refreshes whenever a job reports completion over the WebSocket. This is the
- * place processed files surface, kept separate from normal downloads.
+ * preview, download or delete them. It is backed by the API (so it survives
+ * page reloads) and refreshes whenever a job reports completion over the
+ * WebSocket. This is the place processed files surface, kept separate from
+ * normal downloads.
  */
 export default function ProcessedResults() {
     const [jobs, setJobs] = useState<ToolsJob[]>([])
@@ -49,6 +64,9 @@ export default function ProcessedResults() {
     // ID of the job that completed most recently in this session, so the
     // freshly produced file stands out in the list.
     const [highlightId, setHighlightId] = useState<string | null>(null)
+    // Job whose output is currently expanded in the inline preview player.
+    const [previewId, setPreviewId] = useState<string | null>(null)
+    const [deleteTarget, setDeleteTarget] = useState<ToolsJob | null>(null)
     const subscribe = useWebSocketStore((state) => state.subscribe)
 
     const load = useCallback(async () => {
@@ -82,6 +100,22 @@ export default function ProcessedResults() {
         return () => unsubscribe()
     }, [subscribe, load])
 
+    const handleDelete = async () => {
+        if (!deleteTarget) return
+        try {
+            await deleteToolJob(deleteTarget.id)
+            setJobs((prev) => prev.filter((j) => j.id !== deleteTarget.id))
+            if (previewId === deleteTarget.id) {
+                setPreviewId(null)
+            }
+            toast.success('Processed file deleted')
+        } catch (err) {
+            toast.error(
+                err instanceof Error ? err.message : 'Failed to delete file'
+            )
+        }
+    }
+
     return (
         <Card>
             <CardHeader>
@@ -100,6 +134,13 @@ export default function ProcessedResults() {
                 </div>
             </CardHeader>
             <CardContent>
+                <ConfirmDialog
+                    open={deleteTarget !== null}
+                    onOpenChange={(open) => !open && setDeleteTarget(null)}
+                    title="Delete this processed file?"
+                    description="The output file will be removed from disk. The original downloaded video is not affected."
+                    onConfirm={handleDelete}
+                />
                 {jobs.length === 0 ? (
                     <div className="text-muted-foreground py-8 text-center">
                         <FileVideo className="mx-auto mb-2 h-8 w-8 opacity-50" />
@@ -114,49 +155,114 @@ export default function ProcessedResults() {
                     <div className="divide-y">
                         {jobs.map((job) => {
                             const filename = job.output_file
-                                ? job.output_file.split('/').pop()
+                                ? job.output_file.split('/').pop() || ''
                                 : ''
                             const isNew = job.id === highlightId
+                            const isPreviewing = job.id === previewId
                             return (
                                 <div
                                     key={job.id}
-                                    className={`flex items-center justify-between gap-4 py-3 ${
+                                    className={`py-3 ${
                                         isNew
                                             ? 'bg-primary/5 ring-primary/30 -mx-3 rounded-md px-3 ring-1'
                                             : ''
                                     }`}
                                 >
-                                    <div className="min-w-0">
-                                        <p className="flex items-center gap-2 text-sm font-medium">
-                                            {operationLabel(job.operation_type)}
-                                            {isNew && (
-                                                <Badge className="text-xs">
-                                                    Just processed
-                                                </Badge>
-                                            )}
-                                        </p>
-                                        <p className="text-muted-foreground truncate text-xs">
-                                            {filename}
-                                        </p>
-                                        <p className="text-muted-foreground text-xs">
-                                            {formatDate(
-                                                job.completed_at ||
-                                                    job.updated_at
-                                            )}
-                                            {formatBytes(job.actual_size)
-                                                ? ` · ${formatBytes(job.actual_size)}`
-                                                : ''}
-                                        </p>
+                                    <div className="flex items-center justify-between gap-4">
+                                        <div className="min-w-0">
+                                            <p className="flex items-center gap-2 text-sm font-medium">
+                                                {operationLabel(
+                                                    job.operation_type
+                                                )}
+                                                {isNew && (
+                                                    <Badge className="text-xs">
+                                                        Just processed
+                                                    </Badge>
+                                                )}
+                                            </p>
+                                            <p className="text-muted-foreground truncate text-xs">
+                                                {filename}
+                                            </p>
+                                            <p className="text-muted-foreground text-xs">
+                                                {formatDate(
+                                                    job.completed_at ||
+                                                        job.updated_at
+                                                )}
+                                                {formatBytes(job.actual_size)
+                                                    ? ` · ${formatBytes(job.actual_size)}`
+                                                    : ''}
+                                            </p>
+                                        </div>
+                                        <div className="flex shrink-0 items-center gap-1">
+                                            <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                onClick={() =>
+                                                    setPreviewId(
+                                                        isPreviewing
+                                                            ? null
+                                                            : job.id
+                                                    )
+                                                }
+                                            >
+                                                {isPreviewing ? (
+                                                    <X className="mr-1 h-4 w-4" />
+                                                ) : (
+                                                    <Play className="mr-1 h-4 w-4" />
+                                                )}
+                                                {isPreviewing
+                                                    ? 'Close'
+                                                    : 'Preview'}
+                                            </Button>
+                                            <Button
+                                                asChild
+                                                variant="outline"
+                                                size="sm"
+                                            >
+                                                <a
+                                                    href={toolOutputUrl(job.id)}
+                                                    download={filename || true}
+                                                >
+                                                    <Download className="mr-1 h-4 w-4" />
+                                                    Download
+                                                </a>
+                                            </Button>
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="text-destructive hover:text-destructive"
+                                                aria-label="Delete processed file"
+                                                onClick={() =>
+                                                    setDeleteTarget(job)
+                                                }
+                                            >
+                                                <Trash2 className="h-4 w-4" />
+                                            </Button>
+                                        </div>
                                     </div>
-                                    <Button asChild variant="outline" size="sm">
-                                        <a
-                                            href={toolOutputUrl(job.id)}
-                                            download={filename || true}
-                                        >
-                                            <Download className="mr-2 h-4 w-4" />
-                                            Download
-                                        </a>
-                                    </Button>
+                                    {isPreviewing && (
+                                        <div className="mt-3">
+                                            {fileKind(filename) === 'audio' ? (
+                                                <audio
+                                                    controls
+                                                    autoPlay
+                                                    className="w-full"
+                                                    src={toolOutputPreviewUrl(
+                                                        job.id
+                                                    )}
+                                                />
+                                            ) : (
+                                                <video
+                                                    controls
+                                                    autoPlay
+                                                    className="max-h-96 w-full rounded-md bg-black"
+                                                    src={toolOutputPreviewUrl(
+                                                        job.id
+                                                    )}
+                                                />
+                                            )}
+                                        </div>
+                                    )}
                                 </div>
                             )
                         })}

--- a/web/components/ui/dialog.tsx
+++ b/web/components/ui/dialog.tsx
@@ -1,0 +1,121 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Overlay>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Overlay
+        ref={ref}
+        className={cn(
+            'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80',
+            className
+        )}
+        {...props}
+    />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+    <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+            ref={ref}
+            className={cn(
+                'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg',
+                className
+            )}
+            {...props}
+        >
+            {children}
+            <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none">
+                <X className="h-4 w-4" />
+                <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+        </DialogPrimitive.Content>
+    </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+    className,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn(
+            'flex flex-col space-y-1.5 text-center sm:text-left',
+            className
+        )}
+        {...props}
+    />
+)
+DialogHeader.displayName = 'DialogHeader'
+
+const DialogFooter = ({
+    className,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn(
+            'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+            className
+        )}
+        {...props}
+    />
+)
+DialogFooter.displayName = 'DialogFooter'
+
+const DialogTitle = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Title>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Title
+        ref={ref}
+        className={cn(
+            'text-lg leading-none font-semibold tracking-tight',
+            className
+        )}
+        {...props}
+    />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+    React.ElementRef<typeof DialogPrimitive.Description>,
+    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+    <DialogPrimitive.Description
+        ref={ref}
+        className={cn('text-muted-foreground text-sm', className)}
+        {...props}
+    />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+    Dialog,
+    DialogPortal,
+    DialogOverlay,
+    DialogTrigger,
+    DialogClose,
+    DialogContent,
+    DialogHeader,
+    DialogFooter,
+    DialogTitle,
+    DialogDescription,
+}

--- a/web/services/__tests__/libraryApi.test.ts
+++ b/web/services/__tests__/libraryApi.test.ts
@@ -1,0 +1,77 @@
+import {
+    addJobTags,
+    deleteDownload,
+    listTags,
+    removeJobTag,
+} from '@/services/libraryApi'
+
+describe('libraryApi', () => {
+    const originalFetch = global.fetch
+
+    afterEach(() => {
+        global.fetch = originalFetch
+        vi.restoreAllMocks()
+    })
+
+    function mockFetch(impl: ReturnType<typeof vi.fn>) {
+        global.fetch = impl as unknown as typeof fetch
+    }
+
+    it('lists tags and unwraps the message envelope', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                message: [{ id: 1, name: 'music', count: 3 }],
+            }),
+        })
+        mockFetch(fetchMock)
+
+        const tags = await listTags()
+
+        expect(tags).toEqual([{ id: 1, name: 'music', count: 3 }])
+        expect(fetchMock.mock.calls[0][0]).toContain('/tags')
+    })
+
+    it('adds tags with a POST to the job tags endpoint', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                message: [{ id: 1, name: 'music', source: 'user' }],
+            }),
+        })
+        mockFetch(fetchMock)
+
+        const tags = await addJobTags('job-1', ['music'])
+
+        expect(tags).toHaveLength(1)
+        const [url, opts] = fetchMock.mock.calls[0]
+        expect(url).toContain('/job/job-1/tags')
+        expect(opts.method).toBe('POST')
+        expect(JSON.parse(opts.body)).toEqual({ tags: ['music'] })
+    })
+
+    it('removes a tag with a DELETE request', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+        mockFetch(fetchMock)
+
+        await removeJobTag('job-1', 42)
+
+        const [url, opts] = fetchMock.mock.calls[0]
+        expect(url).toContain('/job/job-1/tags/42')
+        expect(opts.method).toBe('DELETE')
+    })
+
+    it('deletes a download and throws the server error text on failure', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 404,
+            text: async () => 'Job not found',
+        })
+        mockFetch(fetchMock)
+
+        await expect(deleteDownload('missing')).rejects.toThrow('Job not found')
+        const [url, opts] = fetchMock.mock.calls[0]
+        expect(url).toContain('/job/missing')
+        expect(opts.method).toBe('DELETE')
+    })
+})

--- a/web/services/libraryApi.ts
+++ b/web/services/libraryApi.ts
@@ -1,0 +1,87 @@
+import { Tag } from '@/types'
+
+import { SERVER_URL } from '@/lib/env'
+
+/**
+ * Typed client for library management endpoints: tags and download deletion.
+ * Mirrors the conventions of toolsApi.ts (the `{ message }` response envelope
+ * and error extraction).
+ */
+
+const BASE = SERVER_URL ?? ''
+
+interface ApiResponse<T> {
+    message: T
+}
+
+async function parseError(res: Response): Promise<string> {
+    const text = await res.text()
+    if (!text) return `Request failed (${res.status})`
+    try {
+        const json = JSON.parse(text)
+        return json.error || json.message || text
+    } catch {
+        return text.trim()
+    }
+}
+
+/** All tags in the library, with usage counts, most used first. */
+export async function listTags(): Promise<Tag[]> {
+    const res = await fetch(`${BASE}/tags`)
+    if (!res.ok) {
+        throw new Error(await parseError(res))
+    }
+    const data: ApiResponse<Tag[]> = await res.json()
+    return data.message ?? []
+}
+
+/** Tags attached to a single download. */
+export async function getJobTags(jobId: string): Promise<Tag[]> {
+    const res = await fetch(`${BASE}/job/${jobId}/tags`)
+    if (!res.ok) {
+        throw new Error(await parseError(res))
+    }
+    const data: ApiResponse<Tag[]> = await res.json()
+    return data.message ?? []
+}
+
+/** Attach tags to a download; returns the job's full tag list afterwards. */
+export async function addJobTags(
+    jobId: string,
+    tags: string[]
+): Promise<Tag[]> {
+    const res = await fetch(`${BASE}/job/${jobId}/tags`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tags }),
+    })
+    if (!res.ok) {
+        throw new Error(await parseError(res))
+    }
+    const data: ApiResponse<Tag[]> = await res.json()
+    return data.message ?? []
+}
+
+/** Detach a tag from a download. */
+export async function removeJobTag(
+    jobId: string,
+    tagId: number
+): Promise<void> {
+    const res = await fetch(`${BASE}/job/${jobId}/tags/${tagId}`, {
+        method: 'DELETE',
+    })
+    if (!res.ok) {
+        throw new Error(await parseError(res))
+    }
+}
+
+/**
+ * Delete a download from the library. The backend removes the database
+ * records and, for videos, the media file on disk.
+ */
+export async function deleteDownload(jobId: string): Promise<void> {
+    const res = await fetch(`${BASE}/job/${jobId}`, { method: 'DELETE' })
+    if (!res.ok) {
+        throw new Error(await parseError(res))
+    }
+}

--- a/web/services/toolsApi.ts
+++ b/web/services/toolsApi.ts
@@ -93,6 +93,13 @@ export async function cancelToolJob(jobId: string): Promise<void> {
     }
 }
 
+/**
+ * Delete a finished job: the backend removes its record and the output file.
+ * Same endpoint as cancel — the backend cancels running jobs and deletes
+ * finished ones.
+ */
+export const deleteToolJob = cancelToolJob
+
 export async function getToolJob(jobId: string): Promise<ToolsJob> {
     const res = await fetch(`${BASE}/tools/jobs/${jobId}`)
     if (!res.ok) {
@@ -124,4 +131,9 @@ export async function listToolJobs(
 /** URL that streams a completed job's produced file as a download. */
 export function toolOutputUrl(jobId: string): string {
     return `${BASE}/tools/jobs/${jobId}/output`
+}
+
+/** URL that streams the file inline, for in-browser preview/playback. */
+export function toolOutputPreviewUrl(jobId: string): string {
+    return `${BASE}/tools/jobs/${jobId}/output?inline=1`
 }

--- a/web/src/pages/ChannelDetail.tsx
+++ b/web/src/pages/ChannelDetail.tsx
@@ -1,5 +1,7 @@
+import { deleteDownload } from '@/services/libraryApi'
 import { ChannelMetadata, JobWithMetadata, PlaylistItem } from '@/types'
-import { ArrowLeft, Calendar, Play, Users, Video } from 'lucide-react'
+import { ArrowLeft, Calendar, Play, Trash2, Users, Video } from 'lucide-react'
+import { toast } from 'sonner'
 
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -9,6 +11,7 @@ import { SERVER_URL } from '@/lib/env'
 import { getThumbnailUrl } from '@/lib/metadata'
 import { formatBytes, formatSubscriberNumber } from '@/lib/utils'
 
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -20,6 +23,18 @@ export default function ChannelDetailPage() {
     const [channel, setChannel] = useState<JobWithMetadata | null>(null)
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
+    const [deleteOpen, setDeleteOpen] = useState(false)
+
+    const handleDelete = async () => {
+        if (!id) return
+        try {
+            await deleteDownload(id)
+            toast.success('Channel deleted')
+            navigate('/downloads?type=channels')
+        } catch (err) {
+            toast.error(err instanceof Error ? err.message : 'Failed to delete')
+        }
+    }
 
     useEffect(() => {
         const fetchChannel = async () => {
@@ -91,14 +106,30 @@ export default function ChannelDetailPage() {
     return (
         <div className="container mx-auto max-w-6xl p-6">
             {/* Header */}
-            <div className="mb-6">
+            <div className="mb-6 flex items-center justify-between">
                 <Link to="/downloads?type=channels">
                     <Button variant="ghost" className="gap-2">
                         <ArrowLeft className="h-4 w-4" />
                         Back to Channels
                     </Button>
                 </Link>
+                <Button
+                    variant="outline"
+                    className="text-destructive hover:text-destructive gap-2"
+                    onClick={() => setDeleteOpen(true)}
+                >
+                    <Trash2 className="h-4 w-4" />
+                    Delete
+                </Button>
             </div>
+
+            <ConfirmDialog
+                open={deleteOpen}
+                onOpenChange={setDeleteOpen}
+                title="Delete this channel?"
+                description="The channel entry is removed from your library. The videos it contains stay downloaded and remain available individually."
+                onConfirm={handleDelete}
+            />
 
             {/* Channel header */}
             <Card className="mb-8">

--- a/web/src/pages/PlaylistDetail.tsx
+++ b/web/src/pages/PlaylistDetail.tsx
@@ -1,3 +1,4 @@
+import { deleteDownload } from '@/services/libraryApi'
 import { JobWithMetadata, PlaylistMetadata, VideoMetadata } from '@/types'
 import {
     AlertTriangle,
@@ -5,9 +6,11 @@ import {
     Eye,
     List,
     Play,
+    Trash2,
     User,
     XCircle,
 } from 'lucide-react'
+import { toast } from 'sonner'
 
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -17,6 +20,7 @@ import { SERVER_URL } from '@/lib/env'
 import { getThumbnailUrl } from '@/lib/metadata'
 import { formatSubscriberNumber } from '@/lib/utils'
 
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -28,6 +32,18 @@ export default function PlaylistDetailPage() {
     const [videos, setVideos] = useState<JobWithMetadata[]>([])
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
+    const [deleteOpen, setDeleteOpen] = useState(false)
+
+    const handleDelete = async () => {
+        if (!id) return
+        try {
+            await deleteDownload(id)
+            toast.success('Playlist deleted')
+            navigate('/downloads?type=playlists')
+        } catch (err) {
+            toast.error(err instanceof Error ? err.message : 'Failed to delete')
+        }
+    }
 
     useEffect(() => {
         const fetchPlaylist = async () => {
@@ -118,14 +134,30 @@ export default function PlaylistDetailPage() {
     return (
         <div className="container mx-auto max-w-6xl p-6">
             {/* Header */}
-            <div className="mb-6">
+            <div className="mb-6 flex items-center justify-between">
                 <Link to="/downloads?type=playlists">
                     <Button variant="ghost" className="gap-2">
                         <ArrowLeft className="h-4 w-4" />
                         Back to Playlists
                     </Button>
                 </Link>
+                <Button
+                    variant="outline"
+                    className="text-destructive hover:text-destructive gap-2"
+                    onClick={() => setDeleteOpen(true)}
+                >
+                    <Trash2 className="h-4 w-4" />
+                    Delete
+                </Button>
             </div>
+
+            <ConfirmDialog
+                open={deleteOpen}
+                onOpenChange={setDeleteOpen}
+                title="Delete this playlist?"
+                description="The playlist entry is removed from your library. The videos it contains stay downloaded and remain available individually."
+                onConfirm={handleDelete}
+            />
 
             <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
                 {/* Main content - Video list */}

--- a/web/src/pages/VideoDetail.tsx
+++ b/web/src/pages/VideoDetail.tsx
@@ -1,4 +1,5 @@
-import { JobStatusError, JobWithMetadata, VideoMetadata } from '@/types'
+import { deleteDownload } from '@/services/libraryApi'
+import { JobStatusError, JobWithMetadata, Tag, VideoMetadata } from '@/types'
 import {
     AlertTriangle,
     ArrowLeft,
@@ -6,16 +7,20 @@ import {
     Eye,
     List,
     ThumbsUp,
+    Trash2,
     User,
 } from 'lucide-react'
+import { toast } from 'sonner'
 
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useParams } from 'react-router-dom'
 
 import { SERVER_URL } from '@/lib/env'
 import { formatBytes, formatSeconds, formatSubscriberNumber } from '@/lib/utils'
 
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import { TagEditor } from '@/components/tag-editor'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -24,10 +29,24 @@ import VideoPlayer from '@/components/video-player'
 
 export default function VideoDetailPage() {
     const { id } = useParams()
+    const navigate = useNavigate()
     const [video, setVideo] = useState<JobWithMetadata | null>(null)
     const [parents, setParents] = useState<JobWithMetadata[]>([])
+    const [tags, setTags] = useState<Tag[]>([])
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
+    const [deleteOpen, setDeleteOpen] = useState(false)
+
+    const handleDelete = async () => {
+        if (!id) return
+        try {
+            await deleteDownload(id)
+            toast.success('Download deleted')
+            navigate('/downloads')
+        } catch (err) {
+            toast.error(err instanceof Error ? err.message : 'Failed to delete')
+        }
+    }
 
     useEffect(() => {
         const fetchVideo = async () => {
@@ -41,7 +60,9 @@ export default function VideoDetailPage() {
                 }
 
                 const data = await response.json()
-                setVideo(data.message || data)
+                const job: JobWithMetadata = data.message || data
+                setVideo(job)
+                setTags(job.tags || [])
             } catch (err) {
                 console.error('Video fetch error:', err)
                 setError(err instanceof Error ? err.message : 'Unknown error')
@@ -126,13 +147,31 @@ export default function VideoDetailPage() {
                         Back to Downloads
                     </Button>
                 </Link>
-                {isFailed && (
-                    <div className="text-destructive flex items-center gap-2">
-                        <AlertTriangle className="h-5 w-5" />
-                        <span className="font-medium">Download Failed</span>
-                    </div>
-                )}
+                <div className="flex items-center gap-4">
+                    {isFailed && (
+                        <div className="text-destructive flex items-center gap-2">
+                            <AlertTriangle className="h-5 w-5" />
+                            <span className="font-medium">Download Failed</span>
+                        </div>
+                    )}
+                    <Button
+                        variant="outline"
+                        className="text-destructive hover:text-destructive gap-2"
+                        onClick={() => setDeleteOpen(true)}
+                    >
+                        <Trash2 className="h-4 w-4" />
+                        Delete
+                    </Button>
+                </div>
             </div>
+
+            <ConfirmDialog
+                open={deleteOpen}
+                onOpenChange={setDeleteOpen}
+                title="Delete this download?"
+                description="The video file will be removed from disk along with its metadata and tags. This cannot be undone."
+                onConfirm={handleDelete}
+            />
 
             <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
                 {/* Main content */}
@@ -388,36 +427,20 @@ export default function VideoDetailPage() {
                     </Card>
 
                     {/* Tags */}
-                    {metadata?.tags && metadata.tags.length > 0 && (
-                        <Card>
-                            <CardHeader>
-                                <CardTitle className="text-lg">Tags</CardTitle>
-                            </CardHeader>
-                            <CardContent>
-                                <div className="flex flex-wrap gap-2">
-                                    {metadata.tags
-                                        .slice(0, 10)
-                                        .map((tag, index) => (
-                                            <Badge
-                                                key={index}
-                                                variant="secondary"
-                                                className="text-xs"
-                                            >
-                                                {tag}
-                                            </Badge>
-                                        ))}
-                                    {metadata.tags.length > 10 && (
-                                        <Badge
-                                            variant="outline"
-                                            className="text-xs"
-                                        >
-                                            +{metadata.tags.length - 10} more
-                                        </Badge>
-                                    )}
-                                </div>
-                            </CardContent>
-                        </Card>
-                    )}
+                    <Card>
+                        <CardHeader>
+                            <CardTitle className="text-lg">Tags</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            {id && (
+                                <TagEditor
+                                    jobId={id}
+                                    tags={tags}
+                                    onChange={setTags}
+                                />
+                            )}
+                        </CardContent>
+                    </Card>
 
                     {/* Technical info */}
                     <Card>

--- a/web/types/index.ts
+++ b/web/types/index.ts
@@ -21,6 +21,17 @@ export interface Job {
 }
 
 export type JobRepository = any;
+/**
+ * MetadataQuery holds the listing options for GetMetadataByType.
+ */
+export interface MetadataQuery {
+  Page: number /* int */;
+  Limit: number /* int */;
+  SortBy: string;
+  Order: string;
+  Search: string; // case-insensitive match against title/channel
+  Tag: string; // only items carrying this tag
+}
 export type JobType = string;
 export const JobTypeVideo: JobType = "video";
 export const JobTypeAudio: JobType = "audio";
@@ -31,6 +42,7 @@ export const JobTypeMetadata: JobType = "metadata";
 export interface JobWithMetadata {
   job?: Job;
   metadata?: Metadata;
+  tags?: Tag[];
 }
 export interface ProgressUpdate {
   jobID: string;
@@ -191,6 +203,29 @@ export interface VideoStorageInfo {
   title: string;
   size: number /* int */;
   channel: string;
+}
+
+//////////
+// source: tags.go
+
+/**
+ * TagSource records how a tag got attached to a job.
+ */
+export const TagSourceUser = "user";
+/**
+ * TagSource records how a tag got attached to a job.
+ */
+export const TagSourceAuto = "auto";
+/**
+ * Tag is a label attached to a downloaded video, playlist or channel. Count is
+ * only populated when listing the tag catalog; Source is only populated when a
+ * tag is returned in the context of a specific job.
+ */
+export interface Tag {
+  id: number /* int64 */;
+  name: string;
+  source?: string;
+  count?: number /* int */;
 }
 
 //////////


### PR DESCRIPTION
## Summary
Implements a comprehensive tagging system for organizing downloaded videos, playlists, and channels, along with the ability to delete downloads from the library. Tags can be manually added by users or automatically derived from video metadata (categories, channel name, keywords). The system includes search and tag filtering for the downloads library.

## Key Changes

### Backend
- **New tagging domain** (`services/backend/internal/domain/tags.go`):
  - `Tag` struct with ID, name, source (user/auto), and usage count
  - `AutoTagsFor()` function derives tags from metadata (categories, channel, keywords)
  - `NormalizeTagName()` for case-insensitive tag matching

- **Tag repository methods** (`services/backend/internal/repositories/sqlite/job_repository_tags.go`):
  - `ListTags()` - returns tag catalog with usage counts
  - `GetTagsForJob()` - retrieves tags for a specific download
  - `AddTagsToJob()` - attaches tags (creates missing ones, prevents duplicates)
  - `RemoveTagFromJob()` - detaches tags and prunes orphans
  - `applyAutoTags()` - automatically tags downloads when metadata is stored

- **Download deletion** (`services/backend/internal/services/download/service.go`):
  - `DeleteJob()` method cancels running jobs, removes media files, and deletes database records
  - Playlists/channels delete only the parent record; contained videos remain

- **API endpoints** (`services/backend/internal/api/handlers/handlers.go`):
  - `GET /tags` - list all tags with usage counts
  - `GET /job/{id}/tags` - get tags for a download
  - `POST /job/{id}/tags` - add tags to a download
  - `DELETE /job/{id}/tags/{tagID}` - remove a tag
  - `DELETE /job/{id}` - delete a download

- **Search and filtering** (`services/backend/internal/repositories/sqlite/job_repository.go`):
  - `GetMetadataByType()` now accepts `MetadataQuery` struct with `Search` and `Tag` fields
  - Search matches title and channel name with proper SQL LIKE escaping
  - Tag filter narrows results to downloads carrying a specific tag

- **Database schema**:
  - New `tags` table (id, name, created_at with NOCASE collation)
  - New `job_tags` junction table (job_id, tag_id, source, created_at)
  - Migration support for existing databases

### Frontend
- **Library filters component** (`web/components/downloads/LibraryFilters.tsx`):
  - Search input with debouncing (300ms)
  - Tag dropdown showing all tags with usage counts
  - Clear button for search field

- **Tag editor component** (`web/components/tag-editor.tsx`):
  - Display tags with visual distinction for auto-generated tags (sparkle icon)
  - Add new tags via input field
  - Remove tags with confirmation

- **Confirmation dialog** (`web/components/confirm-dialog.tsx`):
  - Reusable component for destructive actions
  - Shows loading state during async operations

- **Library API client** (`web/services/libraryApi.ts`):
  - `listTags()` - fetch tag catalog
  - `getJobTags()` - fetch tags for a download
  - `addJobTags()` - add tags to a download
  - `removeJobTag()` - remove a tag
  - `deleteDownload()` - delete a download

- **Download detail pages**:
  - Video, Playlist, and Channel detail pages now include delete button with confirmation
  - Video detail page includes tag editor for managing tags

- **Downloads grid**:
  - Display tags on video cards in the library

- **Type definitions**:
  - New `Tag` interface with id, name, source, count
  - `MetadataQuery` struct for search/filter options
  - `JobWithMetadata` now includes `tags` field

### Testing
- Comprehensive test suite for tagging functionality (`services/backend/internal/repositories/sqlite/job_repository_tags_

https://claude.ai/code/session_0119MGwYJ5TDBACNyTjKUU98